### PR TITLE
Promote this repo to be included in fedwiki and a part of the standard wiki install.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,18 +1,19 @@
 # Federated Wiki - Security Plug-in: Friends
 
-This module creates its own secrets which it maintains in the `status/owner.json` file. No internet access is necessary to claim sites at will and insure insure single owner access once claimed. We expect a farm operator is "friends" with each user and is available to help restore the long-lived session should it be lost.
+This module creates its own secrets which it maintains in the `status/owner.json` file. No internet access is necessary to claim sites at will and ensure single owner access once claimed. We expect a farm operator is "friends" with each user and is available to help restore the long-lived session should it be lost.
 
-Write access to a claimed site can be restored by following a reclaim link of the form:
-```
-http://site.example.com/auth/reclaim/73aa69f4a5f904272a56a09e31cb580e8d01dbd4b9c3f5d2867f2b25bbfb0114
-```
-where the hex code has been retrieved from the `status.owner.json` file by the friendly site operator.
+Write access to a claimed site can be restored by clicking on the padlock and pasting in the site's
+secret. This can be retrieved from the `status/owner.json` file by the site operator.
 
 ## Configuration
 
-Launch the wiki server with two additional arguments, security_type and cookieSecret.
+Launch the wiki server with three additional arguments, `security_type`, `cookieSecret` and `session_duration`.
 
-- --security_type friends
-- --cookieSecret 'CONSISTENT-SECRET'
+```
+--security_type friends
+--cookieSecret 'REPLACE-THIS-SECRET'
+--session_duration n
+```
 
-The security_type friends specifies to handle authentication with this module. The CONSISTENT-SECRET makes sure that the session cookie encryption is consistent between server restarts. Otherwise each site owner would be logged out and would need to use the auth/reclaim to acquire a new session.
+The security_type friends specifies to handle authentication with this module. Setting a `cookieSecret` makes sure that the session cookie encryption is consistent between server restarts. Otherwise each wiki owner would be logged out following a wiki server restart and would need to use the reclaim code to acquire a new session.
+Setting a `session_duration` allows you to set a longer time for the sites sessions. `n` is the number of days that the session will last, the default is 7 days.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "wiki-security-friends",
   "description": "A friendly security module (dependency free) for Federated Wiki node server",
-  "version": "0.1.0-alpha.1",
+  "version": "1.0.0",
   "author": "Paul Rodwell <paul.rodwell@btinternet.com> (http://rodwell.me/)",
   "contributors": [
     "Ward Cunningham <ward@c2.com>"
@@ -22,10 +22,10 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/paul90/wiki-security-friends.git"
+    "url": "https://github.com/fedwiki/wiki-security-friends.git"
   },
   "bugs": {
-    "url": "https://github.com/paul90/wiki-security-friends/issues"
+    "url": "https://github.com/fedwiki/wiki-security-friends/issues"
   },
   "engines": {
     "node": ">=4"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "wiki-security-friends",
   "description": "A friendly security module (dependency free) for Federated Wiki node server",
-  "version": "1.0.0",
+  "version": "0.1.0",
   "author": "Paul Rodwell <paul.rodwell@btinternet.com> (http://rodwell.me/)",
   "contributors": [
     "Ward Cunningham <ward@c2.com>"
@@ -13,12 +13,12 @@
   },
   "devDependencies": {
     "coffeeify": "*",
-    "es6-promise": "^3.3.1",
+    "es6-promise": "^4.0.5",
     "grunt": "^1.0.1",
     "grunt-browserify": "^5.0.0",
     "grunt-contrib-watch": "^1.0.0",
     "grunt-git-authors": "^3.2.0",
-    "whatwg-fetch": "^1.0.0"
+    "whatwg-fetch": "^2.0.1"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
I'd like to suggest that this security module is ready to be published and included into the standard wiki npm install. Please revise this list of things to do if I have missed any.

- [ ] merge this package.json update
- [x] move the repo to the fedwiki org
- [ ] publish on npm
- [ ] add to the wiki dependents
- [ ] publish a revised wiki on npm

