### PR TITLE
update state

### DIFF
--- a/client/security.coffee
+++ b/client/security.coffee
@@ -36,6 +36,7 @@ update_footer = (ownerName, isAuthenticated) ->
       fetch '/logout', myInit
       .then (response) ->
         if response.ok
+          window.isAuthenticated = false
           update_footer ownerName, false
         else
           console.log 'logout failed: ', response
@@ -58,6 +59,7 @@ update_footer = (ownerName, isAuthenticated) ->
             response.json().then (json) ->
               ownerName = json.ownerName
               window.isClaimed = true
+              window.isAuthenticated = true
               update_footer ownerName, true
           else
             console.log 'login failed: ', response
@@ -82,6 +84,7 @@ update_footer = (ownerName, isAuthenticated) ->
           .then (response) ->
             console.log 'reclaim response', response
             if response.ok
+              window.isAuthenticated = true
               update_footer ownerName, true
             else
               console.log 'reclaim failed: ', response

--- a/package.json
+++ b/package.json
@@ -8,17 +8,17 @@
   ],
   "license": "MIT",
   "dependencies": {
-    "coffee-script": "^1.11.1",
+    "coffee-script": "^1.12.4",
     "seedrandom": "^2.4"
   },
   "devDependencies": {
-    "coffeeify": "*",
-    "es6-promise": "^4.0.5",
+    "coffeeify": "^2.1.0",
+    "es6-promise": "^4.1.0",
     "grunt": "^1.0.1",
     "grunt-browserify": "^5.0.0",
     "grunt-contrib-watch": "^1.0.0",
     "grunt-git-authors": "^3.2.0",
-    "whatwg-fetch": "^2.0.1"
+    "whatwg-fetch": "^2.0.3"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
For some inexplicable reason the authentication state, held by `window.isAuthenticated` was not kept in sync with the cookie. This pull request corrects this.

Something to note is that the friends code does not contain the code to monitor an authentication state change within a wiki domain. While this probably needs to be added, I have a nagging feeling it was left out for a reason...