### PR TITLE
Fix error about Math.seedrandom.

### DIFF
--- a/server/friends.coffee
+++ b/server/friends.coffee
@@ -15,7 +15,7 @@
 #### Requires ####
 console.log 'friends starting'
 fs = require 'fs'
-require 'seedrandom'
+seedrandom = require 'seedrandom'
 
 
 # Export a function that generates security handler
@@ -33,7 +33,7 @@ module.exports = exports = (log, loga, argv) ->
   idFile = argv.id
 
   nickname = (seed) ->
-    rn = new Math.seedrandom(seed)
+    rn = seedrandom(seed)
     c = "bcdfghjklmnprstvwy"
     v = "aeiou"
     ch = (string) -> string.charAt Math.floor rn() * string.length


### PR DESCRIPTION
When attempting to claim a wiki w/ friends security on a new laptop, I get this error:
```
TypeError: Math.seedrandom is not a constructor
    at nickname (/home/joshuabenuck/play/wiki-security-friends/server/friends.coffee:36:10)
```
From the seedrandom [readme](https://github.com/davidbau/seedrandom#cjs--nodejs-usage)
> Starting in version 3, when using via require('seedrandom'), the global Math.seedrandom is no longer available.

We need to switch to saving a reference when requiring the module. This PR does that.

Note: We updated from version 2.4.4 to 3.0.1 in eb5c7b737ad1d418a1b69001c6a3fb962ef393e3.