### PR TITLE
Prevent user's reclaim code being shown

### DIFF
--- a/client/security.coffee
+++ b/client/security.coffee
@@ -27,7 +27,7 @@ update_footer = (ownerName, isAuthenticated) ->
 
   if isAuthenticated
     $('footer > #security').append "<a href='#' id='logout' class='footer-item' title='Sign-out'><i class='fas fa-lock-open fa-fw'></i></a>"
-    $('footer > #security > #logout').click (e) ->
+    $('footer > #security > #logout').on 'click', (e) ->
       e.preventDefault()
       myInit = {
         method: 'GET'
@@ -47,7 +47,7 @@ update_footer = (ownerName, isAuthenticated) ->
     if !isClaimed
       signonTitle = 'Claim this Wiki'
       $('footer > #security').append "<a href='#' id='show-security-dialog' class='footer-item' title='#{signonTitle}'><i class='fas fa-lock fa-fw'></i></a>"
-      $('footer > #security > #show-security-dialog').click (e) ->
+      $('footer > #security > #show-security-dialog').on 'click', (e) ->
         myInit = {
           method: 'POST'
           cache: 'no-cache'
@@ -68,7 +68,7 @@ update_footer = (ownerName, isAuthenticated) ->
     else
       signonTitle = 'Reclaim this Wiki'
       $('footer > #security').append "<a href='#' id='show-security-dialog' class='footer-item' title='#{signonTitle}'><i class='fas fa-lock fa-fw'></i></a>"
-      $('footer > #security > #show-security-dialog').click (e) ->
+      $('footer > #security > #show-security-dialog').on 'click', (e) ->
         reclaimMessage = "Welcome back #{ownerName}. Please enter your reclaim code to reconnect with your wiki."
         reclaimCode = ''
         reclaimCode = window.prompt(reclaimMessage)

--- a/client/security.coffee
+++ b/client/security.coffee
@@ -26,7 +26,10 @@ update_footer = (ownerName, isAuthenticated) ->
   $('footer > #security').empty()
 
   if isAuthenticated
-    $('footer > #security').append "<a href='#' id='logout' class='footer-item' title='Sign-out'><i class='fas fa-lock-open fa-fw'></i></a>"
+    if isOwner
+      $('footer > #security').append "<a href='#' id='logout' class='footer-item' title='Sign-out'><i class='fas fa-lock-open fa-fw'></i></a>"
+    else
+      $('footer > #security').append "<a href='#' id='logout' class='footer-item' title='Not Owner : Sign-out'><i class='fas fa-lock fa-fw notOwner'></i></a>"
     $('footer > #security > #logout').on 'click', (e) ->
       e.preventDefault()
       myInit = {

--- a/client/style.css
+++ b/client/style.css
@@ -6,3 +6,7 @@
 #isOwner {
   color: green;
 }
+
+.notOwner {
+  transform: rotate(20deg);
+}

--- a/server/friends.coffee
+++ b/server/friends.coffee
@@ -77,7 +77,7 @@ module.exports = exports = (log, loga, argv) ->
 
   security.getUser = (req) ->
     if req.session.friend
-      return req.session.friend
+      return true
     else
       return ''
 


### PR DESCRIPTION
Also includes:
* only show unlocked padlock if owner, if logged in and not owner lock will be tilted.
* updates for later jQuery version.