### PR TITLE
Modify reclaim dialog to also submit on enter press in input element

### DIFF
--- a/server/friends.coffee
+++ b/server/friends.coffee
@@ -49,7 +49,12 @@ module.exports = exports = (log, loga, argv) ->
       if exists
         fs.readFile(idFile, (err, data) ->
           if err then return cb err
-          owner = JSON.parse(data)
+          try
+            owner = JSON.parse(data)
+          catch parseError
+            console.error "Error parsing owner file #{idFile}", parseError
+            owner = {name: "syntax error", friend: {secret: null}}
+            return cb()
           cb())
       else
         owner = ''


### PR DESCRIPTION
Moved the fetch to /auth/reclaim/ endpoint into form submit event, rather than dialog close event. This makes it so enter press on input element will also submit form, and try to authenticate.

made cancel button close the dialog, which no longer implies trying to authenticate.