### PR TITLE
Feature/reclaim dialog usability

### DIFF
--- a/client/security.coffee
+++ b/client/security.coffee
@@ -75,6 +75,11 @@ update_footer = (ownerName, isAuthenticated) ->
         reclaimDialog = document.getElementById('reclaim')
 
         reclaimDialog.showModal()
+        requestAnimationFrame ->
+          reclaimEl = reclaimDialog.querySelector('#reclaimcode')
+          reclaimEl.focus()
+          # selecting the input text allows the user to easily overwrite an existing code
+          reclaimEl.select()
 
 
 
@@ -89,15 +94,15 @@ setup = (user) ->
     $('<link rel="stylesheet" href="/security/style.css">').appendTo("head")
 
   dialog = """
-            <dialog id="reclaim">
-              <form method="dialog">
+            <dialog id="reclaim"">
+              <form method="dialog" id="reclaim-form">
                 <h1>Welcome back #{ownerName}.</h1>
                 <p>Please enter your reclaim code.</p>
-                <input type="password" id="reclaimcode" name="reclaim" required>
+                <input type="password" id="reclaimcode" name="reclaim" autofocus required>
                 <div>
                   <menu>
-                    <li><button formmethod="dialog" value="">Cancel</button></li>
-                    <li><button autofocus id="confirmBtn" value="default">Submit</button></li>
+                    <li><button id="cancelBtn" type="button">Cancel</button></li>
+                    <li><button id="confirmBtn">Submit</button></li>
                   </menu>
                 </div>
               </form>
@@ -107,19 +112,13 @@ setup = (user) ->
     $(dialog).appendTo("body")
 
     reclaimDialog = document.getElementById('reclaim')
+    reclaimForm = reclaimDialog.querySelector('#reclaim-form')
     reclaimEl = reclaimDialog.querySelector('#reclaimcode')
-    confirmBtn = reclaimDialog.querySelector('#confirmBtn')
-
-    confirmBtn.addEventListener 'click', (event) -> 
+    cancelBtn = reclaimDialog.querySelector('#cancelBtn')
+    
+    reclaimForm.addEventListener 'submit', (event) -> 
       event.preventDefault()
-      reclaimDialog.close(reclaimEl.value)
-
-    reclaimEl.addEventListener 'change', (event) ->
-      confirmBtn.value = reclaimEl.value
-
-    reclaimDialog.addEventListener 'close', (event) ->
-      event.preventDefault()
-      reclaimCode = reclaimDialog.returnValue
+      reclaimCode = reclaimEl.value
     
       unless reclaimCode is ''
         data = new FormData()
@@ -140,6 +139,11 @@ setup = (user) ->
             update_footer ownerName, true
           else
             console.log 'reclaim failed: ', response
+
+      reclaimDialog.close()
+
+    cancelBtn.addEventListener 'click', (event) ->
+      reclaimDialog.close()
 
   update_footer ownerName, isAuthenticated
 

--- a/server/friends.coffee
+++ b/server/friends.coffee
@@ -49,7 +49,12 @@ module.exports = exports = (log, loga, argv) ->
       if exists
         fs.readFile(idFile, (err, data) ->
           if err then return cb err
-          owner = JSON.parse(data)
+          try
+            owner = JSON.parse(data)
+          catch parseError
+            console.error "Error parsing owner file #{idFile}", parseError
+            owner = {name: "syntax error", friend: {secret: null}}
+            return cb()
           cb())
       else
         owner = ''


### PR DESCRIPTION
Clearly I have some things to learn about git, and branches, and how to submit PRs without combining multiple things together.

This PR was only meant to restore a previous PR that I had done at the link below that I somehow clobbered:
https://github.com/fedwiki/wiki-security-friends/pull/17

I tried to submit these two PRs as distinct things, but failed. I'll try harder next time...

anyhow, you can see from the link above I tested that these edits would also work on MacOS...

To recap, this edit fixes how the reclaim code dialog works in a few small ways. 

1. It puts autofocus on the input box for the secret, and selects all text, so that it can be immediately edited
2. It makes it so that hitting enter while in the input box will submit the form and attempt to authenticate.
3. It makes the cancel button functional. Currently the cancel button doesn't do anything, and the only way to close the dialog is to hit escape.

Somehow this PR is also including the code from this other PR:
https://github.com/fedwiki/wiki-security-friends/pull/20