### PR TITLE
Automatically focus on the reclaim code input box and select all contents

### DIFF
--- a/client/security.coffee
+++ b/client/security.coffee
@@ -75,6 +75,11 @@ update_footer = (ownerName, isAuthenticated) ->
         reclaimDialog = document.getElementById('reclaim')
 
         reclaimDialog.showModal()
+        requestAnimationFrame ->
+          reclaimEl = reclaimDialog.querySelector('#reclaimcode')
+          reclaimEl.focus()
+          # selecting the input text allows the user to easily overwrite an existing code
+          reclaimEl.select()
 
 
 
@@ -89,15 +94,15 @@ setup = (user) ->
     $('<link rel="stylesheet" href="/security/style.css">').appendTo("head")
 
   dialog = """
-            <dialog id="reclaim">
-              <form method="dialog">
+            <dialog id="reclaim"">
+              <form method="dialog" id="reclaim-form">
                 <h1>Welcome back #{ownerName}.</h1>
                 <p>Please enter your reclaim code.</p>
-                <input type="password" id="reclaimcode" name="reclaim" required>
+                <input type="password" id="reclaimcode" name="reclaim" autofocus required>
                 <div>
                   <menu>
-                    <li><button formmethod="dialog" value="">Cancel</button></li>
-                    <li><button autofocus id="confirmBtn" value="default">Submit</button></li>
+                    <li><button id="cancelBtn" type="button">Cancel</button></li>
+                    <li><button id="confirmBtn">Submit</button></li>
                   </menu>
                 </div>
               </form>
@@ -107,19 +112,13 @@ setup = (user) ->
     $(dialog).appendTo("body")
 
     reclaimDialog = document.getElementById('reclaim')
+    reclaimForm = reclaimDialog.querySelector('#reclaim-form')
     reclaimEl = reclaimDialog.querySelector('#reclaimcode')
-    confirmBtn = reclaimDialog.querySelector('#confirmBtn')
-
-    confirmBtn.addEventListener 'click', (event) -> 
+    cancelBtn = reclaimDialog.querySelector('#cancelBtn')
+    
+    reclaimForm.addEventListener 'submit', (event) -> 
       event.preventDefault()
-      reclaimDialog.close(reclaimEl.value)
-
-    reclaimEl.addEventListener 'change', (event) ->
-      confirmBtn.value = reclaimEl.value
-
-    reclaimDialog.addEventListener 'close', (event) ->
-      event.preventDefault()
-      reclaimCode = reclaimDialog.returnValue
+      reclaimCode = reclaimEl.value
     
       unless reclaimCode is ''
         data = new FormData()
@@ -140,6 +139,11 @@ setup = (user) ->
             update_footer ownerName, true
           else
             console.log 'reclaim failed: ', response
+
+      reclaimDialog.close()
+
+    cancelBtn.addEventListener 'click', (event) ->
+      reclaimDialog.close()
 
   update_footer ownerName, isAuthenticated
 

--- a/client/security.coffee
+++ b/client/security.coffee
@@ -115,6 +115,7 @@ setup = (user) ->
     reclaimForm = reclaimDialog.querySelector('#reclaim-form')
     reclaimEl = reclaimDialog.querySelector('#reclaimcode')
     cancelBtn = reclaimDialog.querySelector('#cancelBtn')
+    
     reclaimForm.addEventListener 'submit', (event) -> 
       event.preventDefault()
       reclaimCode = reclaimEl.value

--- a/client/security.coffee
+++ b/client/security.coffee
@@ -102,7 +102,7 @@ setup = (user) ->
                 <div>
                   <menu>
                     <li><button id="cancelBtn">Cancel</button></li>
-                    <li><button autofocus id="confirmBtn">Submit</button></li>
+                    <li><button id="confirmBtn">Submit</button></li>
                   </menu>
                 </div>
               </form>

--- a/client/security.coffee
+++ b/client/security.coffee
@@ -115,8 +115,8 @@ setup = (user) ->
     reclaimForm = reclaimDialog.querySelector('#reclaim-form')
     reclaimEl = reclaimDialog.querySelector('#reclaimcode')
     cancelBtn = reclaimDialog.querySelector('#cancelBtn')
-    
-    reclaimForm.addEventListener 'submit', (event) -> 
+
+    reclaimForm.addEventListener 'submit', (event) ->
       event.preventDefault()
       reclaimCode = reclaimEl.value
 

--- a/client/security.coffee
+++ b/client/security.coffee
@@ -143,11 +143,6 @@ setup = (user) ->
     cancelBtn.addEventListener 'click', (event) ->
       reclaimDialog.close()
 
-      reclaimDialog.close()
-
-    cancelBtn.addEventListener 'click', (event) ->
-      reclaimDialog.close()
-
   update_footer ownerName, isAuthenticated
 
 window.plugins.security = {setup, update_footer}

--- a/server/friends.coffee
+++ b/server/friends.coffee
@@ -49,7 +49,12 @@ module.exports = exports = (log, loga, argv) ->
       if exists
         fs.readFile(idFile, (err, data) ->
           if err then return cb err
-          owner = JSON.parse(data)
+          try
+            owner = JSON.parse(data)
+          catch parseError
+            console.error "Error parsing owner file #{idFile}", parseError
+            owner = {name: "syntax error", friend: {secret: null}}
+            return cb()
           cb())
       else
         owner = ''


### PR DESCRIPTION
This makes it so the input box for the reclaim code has autofocus when the dialog opens up, and if the input box has contents in it, it also selects all of it so that you can immediately start replacing the contents if you like. Hitting enter if the code should already be correct also just submits it.